### PR TITLE
MyFamilyTree | Removing clone option while user is in edit mode

### DIFF
--- a/src/app/family-tree/family-tree.component.html
+++ b/src/app/family-tree/family-tree.component.html
@@ -129,7 +129,7 @@
         </div>
       </div>
 
-      <div class="field">
+      <div class="field" *ngIf="!isEditMode">
         <label>{{ t['mft_add_as'] }}</label>
         <p-selectButton [options]="relationTypes" [(ngModel)]="addingRelation" optionLabel="label"
           optionValue="value"></p-selectButton>
@@ -139,7 +139,7 @@
         <div class="flex gap-2">
           <button pButton [label]="t['mft_save_details']" class="btn-save" (click)="saveDetails()"
             [disabled]="!isFormChanged()"></button>
-          <button pButton [label]="t['mft_add_member']" class="btn-add" (click)="addFamilyMember()" [disabled]="!form.name"></button>
+          <button *ngIf="!isEditMode" pButton [label]="t['mft_add_member']" class="btn-add" (click)="addFamilyMember()" [disabled]="!form.name"></button>
         </div>
         <button *ngIf="selectedNode && getTotalNodeCount(data) > 1" pButton [label]="t['mft_delete']" icon="pi pi-trash"
           class="p-button-danger" (click)="deleteNode(selectedNode)" pTooltip="{{ t['mft_delete_node'] || 'Delete Node' }}"

--- a/src/app/family-tree/family-tree.component.ts
+++ b/src/app/family-tree/family-tree.component.ts
@@ -257,10 +257,11 @@ export class FamilyTreeComponent implements OnInit {
     if (!this.selectedNode || !this.form.name) return;
 
     const formCopy = { ...this.form };
-    formCopy.dob = formCopy.dob;
+    formCopy.dob = null;
     formCopy.diedOn = formCopy.isAlive ? null : formCopy.diedOn;
-    formCopy.partnerDob = formCopy.partnerDob ? formCopy.partnerDob : null;
-    formCopy.partnerDiedOn = formCopy.partnerIsAlive ? null : formCopy.partnerDiedOn;
+    formCopy.partnerName = '';
+    formCopy.partnerDob = null;
+    formCopy.partnerDiedOn = null;
 
     const newNode: OrganizationChartNode = {
       label: this.form.name,


### PR DESCRIPTION
While editing the details removed ability to clone as parent/child/sibiling